### PR TITLE
yaml configurations, external rdf files support

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,0 +1,23 @@
+name: Pylint
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pylint
+      - name: Analysing the code with pylint
+        run: |
+          pylint $(git ls-files '*.py')

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -18,6 +18,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install pylint
+          pip install -r requirements.txt
       - name: Analysing the code with pylint
         run: |
           pylint $(git ls-files '*.py')

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,7 @@
 **/*.loaded
 .idea
 
-data/countries.ttl
-data/countries.config
+data/*.ttl
+data/*.trig
+data/*.config
+data/*.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added support for YAML configurations.
+- Allow specifying external config/rdf files.
+- Added support for trig files.
+
 ## [v2.15-1.1.0]
 
 ### Changed
 
- - Rewrote `entrypoint.sh` as a Python script
- - Use GraphDB instead of Fuseki
+ - Rewrote `entrypoint.sh` as a Python script.
+ - Use GraphDB instead of Fuseki.
  - On start, check if vocabularies exist in GraphDB instead of keeping track of local .loaded files.
 
 ## [v2.15-1.0.0]

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN /usr/bin/env pip install -r /var/www/requirements.txt
 # Configure Skosmos
 COPY skosmos-repository.ttl /var/www/
 COPY entrypoint.sh /var/www/
+COPY ./src /var/www/src
 COPY entrypoint.py /var/www/
 COPY config-docker-compose.ttl /var/www/html/
 ENTRYPOINT ["/var/www/entrypoint.sh"]

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -10,6 +10,7 @@ import shutil
 import time
 from pathlib import Path
 
+from src.exceptions import InvalidConfigurationException
 from src.graphdb import get_loaded_vocabs, setup_graphdb
 from src.vocabularies import get_file_from_config, get_graph, load_vocab_yaml, load_vocabulary
 
@@ -55,16 +56,21 @@ if __name__ == "__main__":
 
         vocab_config = load_vocab_yaml(path)
 
-        with get_file_from_config(vocab_config['config'], data) as config:
-            graph = get_graph(config)
-            print(f"Graph: {graph}")
-        with get_file_from_config(vocab_config['config'], data) as config:
-            # Reset file pointer
-            append_file(config, "/tmp/config-docker-compose.ttl")
+        try:
+            with get_file_from_config(vocab_config['config'], data) as config:
+                graph = get_graph(config)
+                print(f"Graph: {graph}")
+            with get_file_from_config(vocab_config['config'], data) as config:
+                # Reset file pointer
+                append_file(config, "/tmp/config-docker-compose.ttl")
 
-        always_load = vocab_config['config'].get('alwaysRefresh', False)
+            always_load = vocab_config['config'].get('alwaysRefresh', False)
 
-        if always_load or graph not in loaded_vocabs:
-            print(f"Loading vocabulary {vocab}")
-            load_vocabulary(vocab_config['source'], data, graph)
-            print("... DONE")
+            if always_load or graph not in loaded_vocabs:
+                print(f"Loading vocabulary {vocab}")
+                load_vocabulary(vocab_config['source'], data, graph)
+                print("... DONE")
+        except InvalidConfigurationException as e:
+            print(f"Invalid configuration: {e}")
+            print(f"Skipping vocab '{vocab}'")
+            continue

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -1,34 +1,17 @@
 #!/usr/bin/env python3
-import time
+
+"""
+The python entrypoint initializes the Skosmos dataset before starting the application.
+"""
+
+import glob
 import os
 import shutil
-import glob
-import re
-import urllib.request
+import time
 from pathlib import Path
-from rdflib import ConjunctiveGraph
 
-import yaml
-
-from src.exceptions import InvalidConfigurationException, UnknownAuthenticationTypeException
-from src.graphdb import add_vocabulary, get_loaded_vocabs, setup_graphdb
-
-
-def get_graph(fp):
-    """
-    Get the sparql graph from the given vocab
-    :param fp:  The vocabulary config, a file pointer
-    :return:
-    """
-    for line in fp:
-        # If line is a bytes-like object, we need to decode it
-        try:
-            line = line.decode()
-        except (UnicodeDecodeError, AttributeError):
-            # Already decoded
-            pass
-        if re.search("sparqlGraph", line):
-            return line.strip().split(" ")[1].strip("<>")
+from src.graphdb import get_loaded_vocabs, setup_graphdb
+from src.vocabularies import get_file_from_config, get_graph, load_vocab_yaml, load_vocabulary
 
 
 def append_file(source, dest):
@@ -38,71 +21,13 @@ def append_file(source, dest):
     :param dest:    The path of the destination file.
     :return:
     """
-    with open(dest, "a+") as df:
+    with open(dest, "a+", encoding='utf-8') as df:
         for line in source:
             try:
                 line = line.decode()
             except (UnicodeDecodeError, AttributeError):
                 pass
             df.write(line)
-
-
-def load_vocab_yaml(file_location):
-    """
-    Open a yaml config file and return a dict with its contents
-    :param file_location:
-    :return:
-    """
-    with open(file_location, 'r', encoding='utf-8') as fp:
-        return yaml.safe_load(fp)
-
-
-def get_file_from_config(config_data, data_dir):
-    """
-    Get the config file from yaml data.
-    :param config_data: The configuration, a dict with information about the file.
-    :param data_dir:    The data directory of the application
-    :return:
-    """
-    if config_data['type'] == 'file':
-        return open(f"{data_dir}/{config_data['location']}")
-    elif config_data['type'] == 'fetch':
-        req = urllib.request.Request(config_data['location'])
-        if 'headers' in config_data:
-            for header, val in config_data['headers'].items():
-                req.add_header(header, val)
-
-        if 'auth' in config_data:
-            auth_data = config_data['auth']
-            if auth_data['type'] == 'github':
-                req.add_header('Authorization', f'token {auth_data["token"]}')
-            else:
-                raise UnknownAuthenticationTypeException()
-
-        return urllib.request.urlopen(req)
-    else:
-        raise InvalidConfigurationException("Type must be file")
-
-
-def get_vocab_format(source_data):
-    if 'format' in source_data:
-        return source_data['format']
-    return source_data['location'].split('.')[-1]
-
-
-def load_vocabulary(source_data, data_dir, graph_name):
-    """
-    Load a vocabulary using the source data from the yaml.
-    :param source_data:
-    :param data_dir:
-    :param graph_name:
-    :return:
-    """
-    with get_file_from_config(source_data, data_dir) as vocab_file:
-        # g = ConjunctiveGraph()
-        # g.parse(vocab_file, format=get_vocab_format(source_data))
-        # c = list(g.contexts())[0]
-        add_vocabulary(vocab_file, graph_name, get_vocab_format(source_data))
 
 
 if __name__ == "__main__":

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -1,23 +1,32 @@
 #!/usr/bin/env python3
-
 import time
 import os
 import shutil
 import glob
 import re
-import requests
+import urllib.request
 from pathlib import Path
+from rdflib import ConjunctiveGraph
+
+import yaml
+
+from src.exceptions import InvalidConfigurationException, UnknownAuthenticationTypeException
+from src.graphdb import add_vocabulary, get_loaded_vocabs, setup_graphdb
 
 
-def get_graph(data_dir, vocab_name):
+def get_graph(fp):
     """
     Get the sparql graph from the given vocab
-    :param data_dir: The location of the 'data' directory
-    :param vocab_name:  The vocabulary, a config and ttl should be present
+    :param fp:  The vocabulary config, a file pointer
     :return:
     """
-    file = open(f"{data_dir}/{vocab_name}.config", 'r')
-    for line in file:
+    for line in fp:
+        # If line is a bytes-like object, we need to decode it
+        try:
+            line = line.decode()
+        except (UnicodeDecodeError, AttributeError):
+            # Already decoded
+            pass
         if re.search("sparqlGraph", line):
             return line.strip().split(" ")[1].strip("<>")
 
@@ -25,13 +34,75 @@ def get_graph(data_dir, vocab_name):
 def append_file(source, dest):
     """
     Append source to dest file.
-    :param source:
-    :param dest:
+    :param source:  A file pointer to a source file.
+    :param dest:    The path of the destination file.
     :return:
     """
-    with open(source, "r") as sf:
-        with open(dest, "a+") as df:
-            df.write(sf.read())
+    with open(dest, "a+") as df:
+        for line in source:
+            try:
+                line = line.decode()
+            except (UnicodeDecodeError, AttributeError):
+                pass
+            df.write(line)
+
+
+def load_vocab_yaml(file_location):
+    """
+    Open a yaml config file and return a dict with its contents
+    :param file_location:
+    :return:
+    """
+    with open(file_location, 'r', encoding='utf-8') as fp:
+        return yaml.safe_load(fp)
+
+
+def get_file_from_config(config_data, data_dir):
+    """
+    Get the config file from yaml data.
+    :param config_data: The configuration, a dict with information about the file.
+    :param data_dir:    The data directory of the application
+    :return:
+    """
+    if config_data['type'] == 'file':
+        return open(f"{data_dir}/{config_data['location']}")
+    elif config_data['type'] == 'fetch':
+        req = urllib.request.Request(config_data['location'])
+        if 'headers' in config_data:
+            for header, val in config_data['headers'].items():
+                req.add_header(header, val)
+
+        if 'auth' in config_data:
+            auth_data = config_data['auth']
+            if auth_data['type'] == 'github':
+                req.add_header('Authorization', f'token {auth_data["token"]}')
+            else:
+                raise UnknownAuthenticationTypeException()
+
+        return urllib.request.urlopen(req)
+    else:
+        raise InvalidConfigurationException("Type must be file")
+
+
+def get_vocab_format(source_data):
+    if 'format' in source_data:
+        return source_data['format']
+    return source_data['location'].split('.')[-1]
+
+
+def load_vocabulary(source_data, data_dir, graph_name):
+    """
+    Load a vocabulary using the source data from the yaml.
+    :param source_data:
+    :param data_dir:
+    :param graph_name:
+    :return:
+    """
+    with get_file_from_config(source_data, data_dir) as vocab_file:
+        # g = ConjunctiveGraph()
+        # g.parse(vocab_file, format=get_vocab_format(source_data))
+        # c = list(g.contexts())[0]
+        add_vocabulary(vocab_file, graph_name, get_vocab_format(source_data))
 
 
 if __name__ == "__main__":
@@ -45,65 +116,30 @@ if __name__ == "__main__":
         shutil.copy('/var/www/html/config-docker-compose.ttl', '/tmp/config-docker-compose.ttl')
 
     if os.path.isfile(f'{data}/config-ext.ttl'):
-        append_file(f'{data}/config-ext.ttl', '/tmp/config-docker-compose.ttl')
+        with open(f'{data}/config-ext.ttl', 'r', encoding='utf-8') as f:
+            append_file(f, '/tmp/config-docker-compose.ttl')
 
-    admin_password = os.environ.get("ADMIN_PASSWORD", '')
+    setup_graphdb()
 
-    endpoint = os.environ.get("SPARQL_ENDPOINT", '')
+    loaded_vocabs = get_loaded_vocabs()
 
-    # Check if db exists
-    resp = requests.get(f"{endpoint}/size")
-    if resp.status_code != 200:
-        # GraphDB repository not created yet -- create it
-        headers = {
-            'Content-Type': 'text/turtle',
-        }
-        response = requests.put(
-            f"{endpoint}",
-            headers=headers,
-            data=open(f"/var/www/skosmos-repository.ttl", "rb"),
-            auth=('admin', admin_password),
-        )
-        print(f"CREATED GRAPHDB[{endpoint}] DB[skosmos.tdb]")
-    else:
-        print(f"EXISTS GRAPHDB [{endpoint}]]")
-
-    vocabs = glob.glob(f'{data}/*.ttl')
-
-    graphs_response = requests.get(f"{endpoint}/rdf-graphs",
-                                   headers={"Accept": "application/json"})
-    loaded_vocabs = []
-    if graphs_response.status_code == 200:
-        body = graphs_response.json()
-        loaded_vocabs = []
-        for binding in body["results"]["bindings"]:
-            loaded_vocabs.append(binding["contextID"]["value"])
-        print("Loaded vocabs:")
-        print(loaded_vocabs)
+    vocabs = glob.glob(f'{data}/*.yaml')
 
     for vocab in vocabs:
         path = Path(vocab)
-        basename = path.stem
-        graph = get_graph(data, basename)
-        if graph not in loaded_vocabs:
-            print(f"LOAD VOCAB[{basename}] ...")
-            print(f"... in GRAPH[{graph}] ...")
-            if not os.path.isfile(f'{data}/{basename}.ttl'):
-                print(f"!ERROR {data}/{basename}.ttl doesn't exist!")
-                exit(1)
 
-            headers = {
-                'Content-Type': 'text/turtle',
-            }
-            response = requests.put(
-                f"{endpoint}/statements",
-                data=open(f'{data}/{basename}.ttl', "rb"),
-                headers=headers,
-                auth=('admin', admin_password),
-                params={'context': f"<{graph}>"},
-            )
+        vocab_config = load_vocab_yaml(path)
+
+        with get_file_from_config(vocab_config['config'], data) as config:
+            graph = get_graph(config)
+            print(f"Graph: {graph}")
+        with get_file_from_config(vocab_config['config'], data) as config:
+            # Reset file pointer
+            append_file(config, "/tmp/config-docker-compose.ttl")
+
+        always_load = vocab_config['config'].get('alwaysRefresh', False)
+
+        if always_load or graph not in loaded_vocabs:
+            print(f"Loading vocabulary {vocab}")
+            load_vocabulary(vocab_config['source'], data, graph)
             print("... DONE")
-
-    configs = glob.glob(f'{data}/*.config')
-    for config in configs:
-        append_file(config, "/tmp/config-docker-compose.ttl")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
-requests
+PyYAML==6.0.1
+requests==2.31.0
+rdflib~=7.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-PyYAML==6.0.1
-requests==2.31.0
-rdflib~=7.0.0
+PyYAML~=6.0.1
+requests~=2.31.0

--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -1,0 +1,10 @@
+"""
+This file contains all exceptions raised by the application.
+"""
+
+
+class InvalidConfigurationException(Exception):
+    pass
+
+class UnknownAuthenticationTypeException(Exception):
+    pass

--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -4,7 +4,12 @@ This file contains all exceptions raised by the application.
 
 
 class InvalidConfigurationException(Exception):
-    pass
+    """
+    Exception raised when there is a misconfiguration.
+    """
 
-class UnknownAuthenticationTypeException(Exception):
-    pass
+
+class UnknownAuthenticationTypeException(InvalidConfigurationException):
+    """
+    Exception raised when the authentication type specified is not known.
+    """

--- a/src/graphdb.py
+++ b/src/graphdb.py
@@ -2,7 +2,6 @@
 This file contains functions for interacting with GraphDB
 """
 import os
-
 import requests
 
 admin_password = os.environ.get("ADMIN_PASSWORD", '')
@@ -15,18 +14,20 @@ def setup_graphdb():
     :return:
     """
     # Check if db exists
-    resp = requests.get(f"{endpoint}/size")
+    resp = requests.get(f"{endpoint}/size", timeout=60)
     if resp.status_code != 200:
         # GraphDB repository not created yet -- create it
         headers = {
             'Content-Type': 'text/turtle',
         }
-        requests.put(
-            f"{endpoint}",
-            headers=headers,
-            data=open(f"/var/www/skosmos-repository.ttl", "rb"),
-            auth=('admin', admin_password),
-        )
+        with open("/var/www/skosmos-repository.ttl", "rb") as fp:
+            requests.put(
+                f"{endpoint}",
+                headers=headers,
+                data=fp,
+                auth=('admin', admin_password),
+                timeout=60
+            )
         print(f"CREATED GRAPHDB[{endpoint}] DB[skosmos.tdb]")
     else:
         print(f"EXISTS GRAPHDB [{endpoint}]]")
@@ -37,8 +38,11 @@ def get_loaded_vocabs():
     Get all loaded vocabularies from GraphDB
     :return:
     """
-    graphs_response = requests.get(f"{endpoint}/rdf-graphs",
-                                   headers={"Accept": "application/json"})
+    graphs_response = requests.get(
+        f"{endpoint}/rdf-graphs",
+        headers={"Accept": "application/json"},
+        timeout=60
+    )
     tmp = []
     if graphs_response.status_code == 200:
         body = graphs_response.json()
@@ -51,6 +55,11 @@ def get_loaded_vocabs():
 
 
 def get_type(extension):
+    """
+    Get the http mimetype based on the extension of a file.
+    :param extension:
+    :return:
+    """
     if extension in ["ttl", "turtle"]:
         return "text/turtle"
     if extension in ["trig"]:
@@ -77,6 +86,7 @@ def add_vocabulary(graph, graph_name, extension):
         headers=headers,
         auth=('admin', admin_password),
         params={'context': f"<{graph_name}>"},
+        timeout=60,
     )
     print(f"RESPONSE: {response.status_code}")
     if response.status_code != 200:

--- a/src/graphdb.py
+++ b/src/graphdb.py
@@ -1,0 +1,83 @@
+"""
+This file contains functions for interacting with GraphDB
+"""
+import os
+
+import requests
+
+admin_password = os.environ.get("ADMIN_PASSWORD", '')
+endpoint = os.environ.get("SPARQL_ENDPOINT", '')
+
+
+def setup_graphdb():
+    """
+    Setup graphdb, if it isn't set up yet.
+    :return:
+    """
+    # Check if db exists
+    resp = requests.get(f"{endpoint}/size")
+    if resp.status_code != 200:
+        # GraphDB repository not created yet -- create it
+        headers = {
+            'Content-Type': 'text/turtle',
+        }
+        requests.put(
+            f"{endpoint}",
+            headers=headers,
+            data=open(f"/var/www/skosmos-repository.ttl", "rb"),
+            auth=('admin', admin_password),
+        )
+        print(f"CREATED GRAPHDB[{endpoint}] DB[skosmos.tdb]")
+    else:
+        print(f"EXISTS GRAPHDB [{endpoint}]]")
+
+
+def get_loaded_vocabs():
+    """
+    Get all loaded vocabularies from GraphDB
+    :return:
+    """
+    graphs_response = requests.get(f"{endpoint}/rdf-graphs",
+                                   headers={"Accept": "application/json"})
+    tmp = []
+    if graphs_response.status_code == 200:
+        body = graphs_response.json()
+        tmp = []
+        for binding in body["results"]["bindings"]:
+            tmp.append(binding["contextID"]["value"])
+        print("Loaded vocabs:")
+        print(tmp)
+    return tmp
+
+
+def get_type(extension):
+    if extension in ["ttl", "turtle"]:
+        return "text/turtle"
+    if extension in ["trig"]:
+        return "application/x-trig"
+    # Default
+    return "text/turtle"
+
+
+def add_vocabulary(graph, graph_name, extension):
+    """
+    Add a vocabulary to GraphDB
+    :param graph:       File
+    :param graph_name:  String representing the name of the graph
+    :param extension:    String representing the extension
+    :return:
+    """
+    print(f"Adding vocabulary {graph_name}")
+    headers = {
+        'Content-Type': get_type(extension),
+    }
+    response = requests.put(
+        f"{endpoint}/statements",
+        data=graph.read(),
+        headers=headers,
+        auth=('admin', admin_password),
+        params={'context': f"<{graph_name}>"},
+    )
+    print(f"RESPONSE: {response.status_code}")
+    if response.status_code != 200:
+        print(response.content)

--- a/src/vocabularies.py
+++ b/src/vocabularies.py
@@ -1,0 +1,91 @@
+"""
+This file contains functions for dealing with vocabularies and their configuration.
+"""
+
+import re
+import urllib.request
+import yaml
+
+from src.exceptions import InvalidConfigurationException, UnknownAuthenticationTypeException
+from src.graphdb import add_vocabulary
+
+
+def get_file_from_config(config_data, data_dir):
+    """
+    Get the config file from yaml data.
+    :param config_data: The configuration, a dict with information about the file.
+    :param data_dir:    The data directory of the application
+    :return:
+    """
+    if config_data['type'] == 'file':
+        return open(f"{data_dir}/{config_data['location']}", encoding='utf-8')
+    if config_data['type'] == 'fetch':
+        req = urllib.request.Request(config_data['location'])
+        if 'headers' in config_data:
+            for header, val in config_data['headers'].items():
+                req.add_header(header, val)
+
+        if 'auth' in config_data:
+            auth_data = config_data['auth']
+            if auth_data['type'] == 'github':
+                req.add_header('Authorization', f'token {auth_data["token"]}')
+            else:
+                raise UnknownAuthenticationTypeException()
+
+        return urllib.request.urlopen(req)
+    raise InvalidConfigurationException("Type must be file")
+
+
+def load_vocabulary(source_data, data_dir, graph_name):
+    """
+    Load a vocabulary using the source data from the yaml.
+    :param source_data:
+    :param data_dir:
+    :param graph_name:
+    :return:
+    """
+    with get_file_from_config(source_data, data_dir) as vocab_file:
+        # g = ConjunctiveGraph()
+        # g.parse(vocab_file, format=get_vocab_format(source_data))
+        # c = list(g.contexts())[0]
+        add_vocabulary(vocab_file, graph_name, get_vocab_format(source_data))
+
+
+def get_graph(fp):
+    """
+    Get the sparql graph from the given vocab
+    :param fp:  The vocabulary config, a file pointer
+    :return:
+    """
+    for line in fp:
+        # If line is a bytes-like object, we need to decode it
+        try:
+            line = line.decode()
+        except (UnicodeDecodeError, AttributeError):
+            # Already decoded
+            pass
+        if re.search("sparqlGraph", line):
+            return line.strip().split(" ")[1].strip("<>")
+    return ""
+
+
+def load_vocab_yaml(file_location):
+    """
+    Open a yaml config file and return a dict with its contents
+    :param file_location:
+    :return:
+    """
+    with open(file_location, 'r', encoding='utf-8') as fp:
+        return yaml.safe_load(fp)
+
+
+def get_vocab_format(source_data):
+    """
+    Return the vocab format of the given data source. It is either based on the file extension,
+    or on an override in the yaml file.
+    :param source_data:
+    :return:
+    """
+    if 'format' in source_data:
+        return source_data['format']
+    return source_data['location'].split('.')[-1]


### PR DESCRIPTION
# Added YAML configuration file support

In the `data` folder, instead of iterating through all .ttl and .config files, the application now checks for all yaml files. These yaml files can contain configuration as follows:

```yaml
config:
  type: file
  location: countries.config
source:
  type: file
  location: countries.ttl
```

Vocabularies can also be loaded from an external source. This applies both to the RDF file and the config. In order to do so, specify the `type` as `fetch`. When no filetype is clear from the url (if it ends in something other than the normal file extension), it can be explicitly stated as well:

```yaml
config:
  type: fetch
  location: https://raw.githubusercontent.com/CLARIAH/skosmos/main/data/countries.config.example
source:
  type: fetch
  location: https://raw.githubusercontent.com/CLARIAH/skosmos/main/data/countries.ttl.example
  format: ttl
    # It is also possible to specify additional headers, for other kinds of authentication or content negotiation:
  headers:
    Accept: application/turtle
```

## Getting files from private repositories

### GitHub

When retrieving files from a private GitHub repository, it is also possible to specify an access token. Also note the `alwaysRefresh` setting on the config, which is used to make the application import this dataset again even if it is already imported into the application, to update it:

```yaml
config:
  alwaysRefresh: Yes
  type: fetch
  location: https://raw.githubusercontent.com/organization/private-repository/main/vocab.config
  auth:
    type: github
    token: your_token_here
source:
  type: fetch
  location: https://raw.githubusercontent.com/organization/private-repository/main/vocab.trig
  auth:
    type: github
    token: your_token_here
```

### GitLab

Getting a file from a private GitLab repository uses the URL where the file can be found when browsing the GitLab site and navigating through the code to the file you need. The URL should be similar to the one in the example below. The token you provide must have access to the [Repository Files API](https://docs.gitlab.com/ee/api/repository_files.html).

```yaml
source:
  type: fetch
  location: https://your-gitlab-domain.com/org/repo-name/-/blob/branch-name/path/to/vocab.trig
  auth:
    type: gitlab
    token: your_token_here
```