### PR TITLE
feat: allow tweaking vocabularies when importing

### DIFF
--- a/entrypoint.py
+++ b/entrypoint.py
@@ -75,6 +75,9 @@ def main() -> None:
             if reload:
                 print(f"Loading vocabulary {vocab}")
                 load_vocabulary(vocab_config['source'], data, graph)
+                if "tweaks" in vocab_config:
+                    print(f"Tweaks found for {vocab}. Loading")
+                    load_vocabulary(vocab_config['tweaks'], data, graph, True)
                 if graph in loaded_vocabs:
                     update_timestamp(graph, int(time.time()))
                 else:

--- a/src/graphdb.py
+++ b/src/graphdb.py
@@ -2,7 +2,6 @@
 This file contains functions for interacting with GraphDB
 """
 import os
-import urllib
 from typing import TextIO
 
 import requests

--- a/src/graphdb.py
+++ b/src/graphdb.py
@@ -2,6 +2,7 @@
 This file contains functions for interacting with GraphDB
 """
 import os
+import urllib
 from typing import TextIO
 
 import requests
@@ -124,12 +125,13 @@ def get_type(extension: str) -> str:
     return "application/x-turtle"
 
 
-def add_vocabulary(graph: TextIO, graph_name: str, extension: str) -> None:
+def add_vocabulary(graph: TextIO, graph_name: str, extension: str, append: bool = False) -> None:
     """
     Add a vocabulary to GraphDB
     :param graph:       File
     :param graph_name:  String representing the name of the graph
-    :param extension:    String representing the extension
+    :param extension:   String representing the extension
+    :param append:      Append data instead of replacing
     :return:
     """
     print(f"Adding vocabulary {graph_name}")
@@ -142,7 +144,9 @@ def add_vocabulary(graph: TextIO, graph_name: str, extension: str) -> None:
     headers = {
         'Content-Type': get_type(extension),
     }
-    response = requests.put(
+    method = requests.post if append else requests.put
+
+    response = method(
         f"{endpoint}/statements",
         data=content,
         headers=headers,

--- a/src/vocabularies.py
+++ b/src/vocabularies.py
@@ -97,7 +97,7 @@ def get_file_from_config(config_data: dict, data_dir: str) -> TextIO:
     raise InvalidConfigurationException("Unknown type")
 
 
-def load_vocabulary(source_data: dict, data_dir: str, graph_name: str) -> None:
+def load_vocabulary(source_data: dict, data_dir: str, graph_name: str, append: bool = False) -> None:
     """
     Load a vocabulary using the source data from the yaml.
     :param source_data:
@@ -106,7 +106,7 @@ def load_vocabulary(source_data: dict, data_dir: str, graph_name: str) -> None:
     :return:
     """
     with get_file_from_config(source_data, data_dir) as vocab_file:
-        add_vocabulary(vocab_file, graph_name, get_vocab_format(source_data))
+        add_vocabulary(vocab_file, graph_name, get_vocab_format(source_data), append)
 
 
 def get_graph(fp: IO) -> str:

--- a/src/vocabularies.py
+++ b/src/vocabularies.py
@@ -97,12 +97,14 @@ def get_file_from_config(config_data: dict, data_dir: str) -> TextIO:
     raise InvalidConfigurationException("Unknown type")
 
 
-def load_vocabulary(source_data: dict, data_dir: str, graph_name: str, append: bool = False) -> None:
+def load_vocabulary(source_data: dict, data_dir: str,
+                    graph_name: str, append: bool = False) -> None:
     """
     Load a vocabulary using the source data from the yaml.
-    :param source_data:
-    :param data_dir:
-    :param graph_name:
+    :param source_data: Dict containing the information where to find the vocab.
+    :param data_dir: Dir containing local files.
+    :param graph_name: The name of the graph to put the vocabulary into.
+    :param append: Boolean, when true this doesn't overwrite the graph but appends.
     :return:
     """
     with get_file_from_config(source_data, data_dir) as vocab_file:


### PR DESCRIPTION
Addition to the yaml syntax: option for a 'tweak' ttl file which will be appended after importing a vocabulary. This way, additional properties can be made visible in Skosmos by adding a label to them.