### PR TITLE
fix: add missing labels to config for hierarchy view

### DIFF
--- a/config-docker-compose.ttl
+++ b/config-docker-compose.ttl
@@ -69,4 +69,9 @@
     # plugins to activate for the whole installation (including all vocabularies)
     skosmos:globalPlugins () .
 
+# Add labels. Otherwise, the hierarchy view breaks
+mdrtype:THESAURUS skos:prefLabel "Тезаурус"@bg, "Tezaurus"@cs, "Tesaurus"@da, "Thesaurus"@de, "Θησαυρός"@el, "Thesaurus"@en, "Tesaurus"@et, "Tesaurus"@fi, "Thésaurus"@fr, "Pojmovnik"@hr, "Tezaurusz"@hu, "Tesauro"@it, "Tēzaurs"@lv, "Tezauras"@lt, "Teżawru"@mt, "Thesaurus"@nl, "Tesaurus"@no, "Tezaurus"@pl, "Tesauro"@pt, "Tezaur"@ro, "Synonymický slovník"@sk, "Tezaver"@sl, "Tesauro"@es, "Tesaurus"@sv .
+
+mdrtype:ONTOLOGY skos:prefLabel "Онтология"@bg, "Ontologie"@cs, "Ontologi"@da, "Ontologie"@de, "Οντολογία"@el, "Ontology"@en, "Ontoloogia"@et, "Ontologia"@fi, "Ontologie"@fr, "Ontologija"@hr, "Ontológia"@hu, "Ontologia"@it, "Ontoloģija"@lv, "Ontologija"@lt, "Ontoloġija"@mt, "Ontologie"@nl, "Ontologi"@no, "Struktura pojęciowa"@pl, "Ontologia"@pt, "Ontologie"@ro, "Ontológia"@sk, "Ontologija"@sl, "Ontología"@es, "Ontologi"@sv .
+
 # Skosmos vocabularies


### PR DESCRIPTION
Hierarchy view breaks because it needs to have a label for the type of vocabulary. This adds labels for the ones used in most configs in common languages (found these two lines in the default config by NatLibFi in the Skosmos repo)